### PR TITLE
chore: remove Ansible path from CODEOWNERS

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -3,4 +3,4 @@
 
 # Reviewer for CICD related changes
 .github @bradjohnl
-ansible @bradjohnl
+docker @bradjohnl


### PR DESCRIPTION
This is a small change, mostly to trigger the redeployment of the frontend.